### PR TITLE
Keep the tabs state alive

### DIFF
--- a/example/lib/autoformat_page.dart
+++ b/example/lib/autoformat_page.dart
@@ -30,7 +30,8 @@ class AutoformatPage extends StatefulWidget {
   AutoformatPageState createState() => AutoformatPageState();
 }
 
-class AutoformatPageState extends State<AutoformatPage> {
+class AutoformatPageState extends State<AutoformatPage>
+    with AutomaticKeepAliveClientMixin {
   final key = GlobalKey<FormState>();
 
   Region? region;
@@ -77,6 +78,7 @@ class AutoformatPageState extends State<AutoformatPage> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return Form(
       key: key,
       child: ListView(
@@ -120,4 +122,7 @@ class AutoformatPageState extends State<AutoformatPage> {
       ),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }

--- a/example/lib/functions_page.dart
+++ b/example/lib/functions_page.dart
@@ -22,7 +22,8 @@ class FunctionsPage extends StatefulWidget {
   FunctionsPageState createState() => FunctionsPageState();
 }
 
-class FunctionsPageState extends State<FunctionsPage> {
+class FunctionsPageState extends State<FunctionsPage>
+    with AutomaticKeepAliveClientMixin {
   final regionCtrl = TextEditingController();
   final numberCtrl = TextEditingController();
   final key = GlobalKey<FormState>();
@@ -90,6 +91,7 @@ class FunctionsPageState extends State<FunctionsPage> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return Form(
       key: key,
       child: ListView(
@@ -187,6 +189,9 @@ class FunctionsPageState extends State<FunctionsPage> {
       );
     }
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }
 
 class RegionCode extends StatelessWidget {


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Closes #77

## Solution description
Now the data state in both tabs won't be lost, in contrast, will preserve the states.

## Screenshots or Videos

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
