### PR TITLE
Add region code and update docs for country code 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ PhoneNumber{
   international: +1 417-555-5470,
   national: (417) 555-5470,
   countryCode: 1,
+  regionCode: "US",
   nationalNumber: 4175555470,
   errorCode: null,
 }
@@ -106,6 +107,14 @@ Fetching regions (country code and prefixes).
 ```dart
 List<RegionInfo> regions = await plugin.allSupportedRegions();
 // [ RegionInfo { code: IM, prefix: 44 }, RegionInfo { code: LU, prefix: 352 }, ... ]
+```
+
+A parsed phone number will give region code as well.
+
+```dart
+String springFieldUSASimple = '+14175555470';
+PhoneNumber phoneNumber = await PhoneNumberUtil().parse(springFieldUSASimple);
+phoneNumber.regionCode; // US
 ```
 
 If you want to display all the flags alongside the regions in your UI region picker, consider having a JSON file instead of using this function. [Example JSON file](https://gist.githubusercontent.com/DmytroLisitsyn/1c31186e5b66f1d6c52da6b5c70b12ad/raw/01b1af9b267471818f4f8367852bd4a2814cbae6/country_dial_info.json)

--- a/android/src/main/java/com/julienvignali/phone_number/PhoneNumberPlugin.java
+++ b/android/src/main/java/com/julienvignali/phone_number/PhoneNumberPlugin.java
@@ -164,12 +164,14 @@ public class PhoneNumberPlugin implements FlutterPlugin, MethodCallHandler {
 
       return new HashMap<String, String>() {{
         PhoneNumberType type = util.getNumberType(phoneNumber);
+        int countryCode = phoneNumber.getCountryCode();
         put("type", numberTypeToString(type));
         put("e164", util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.E164));
         put("international",
                 util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.INTERNATIONAL));
         put("national", util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.NATIONAL));
-        put("country_code", String.valueOf(phoneNumber.getCountryCode()));
+        put("country_code", String.valueOf(countryCode));
+        put("region_code", String.valueOf(util.getRegionCodeForCountryCode(countryCode)));
         put("national_number", String.valueOf(phoneNumber.getNationalNumber()));
       }};
     } catch (NumberParseException e) {

--- a/ios/Classes/SwiftPhoneNumberPlugin.swift
+++ b/ios/Classes/SwiftPhoneNumberPlugin.swift
@@ -107,12 +107,15 @@ public class SwiftPhoneNumberPlugin: NSObject, FlutterPlugin {
             // - the number formatted as a national number and without the international prefix
             // - the number type (might not be 100% auccurate)
 
+            var regionCode = kit.getRegionCode(of: phoneNumber)
+
             return [
                 "type": phoneNumber.type.toString(),
                 "e164": kit.format(phoneNumber, toType: .e164),
                 "international": kit.format(phoneNumber, toType: .international, withPrefix: true),
                 "national": kit.format(phoneNumber, toType: .national),
                 "country_code": String(phoneNumber.countryCode),
+                "region_code": String(regionCode ?? ""),
                 "national_number": String(phoneNumber.nationalNumber)
             ]
         } catch {

--- a/lib/src/models/phone_number.dart
+++ b/lib/src/models/phone_number.dart
@@ -4,13 +4,18 @@ import 'package:phone_number/src/models/phone_number_type.dart';
 /// Represents a successfully parsed phone number
 @immutable
 class PhoneNumber {
+  /// Returns the country calling code for a specific region.
+  ///
+  /// Example: 1 for the US, 44 for the UK, 1 for Canada, 61 for Australia, etc.
+  final String countryCode;
+
   /// ISO 3166-1 alpha-2 codes are two-letter country codes defined in ISO 3166-1,
   /// part of the ISO 3166 standard[1] published by the International Organization
   /// for Standardization (ISO), to represent countries, dependent territories, and
   /// special areas of geographical interest.
   ///
-  /// Example: 1
-  final String countryCode;
+  /// Example: US
+  final String regionCode;
 
   /// E.164 is an international standard (ITU-T Recommendation), titled The international
   /// public telecommunication numbering plan, that defines a numbering plan for the
@@ -33,6 +38,7 @@ class PhoneNumber {
 
   const PhoneNumber({
     required this.countryCode,
+    required this.regionCode,
     required this.e164,
     required this.national,
     required this.type,
@@ -43,6 +49,7 @@ class PhoneNumber {
   factory PhoneNumber.fromJson(Map<String, dynamic> json) {
     return PhoneNumber(
         countryCode: json['country_code'],
+        regionCode: json['region_code'],
         e164: json['e164'],
         national: json['national'],
         type: _mapStringToPhoneNumberType(json['type'])!,
@@ -101,6 +108,7 @@ class PhoneNumber {
   @override
   int get hashCode =>
       countryCode.hashCode ^
+      regionCode.hashCode ^
       e164.hashCode ^
       national.hashCode ^
       type.hashCode ^
@@ -113,6 +121,7 @@ class PhoneNumber {
       other is PhoneNumber &&
           runtimeType == other.runtimeType &&
           countryCode == other.countryCode &&
+          regionCode == other.regionCode &&
           e164 == other.e164 &&
           national == other.national &&
           type == other.type &&
@@ -123,6 +132,7 @@ class PhoneNumber {
   String toString() {
     return 'PhoneNumber { '
         'countryCode: $countryCode, '
+        'regionCode: $regionCode, '
         'e164: $e164, '
         'national: $national, '
         'type: $type, '


### PR DESCRIPTION
## Connection with issue(s)

Close #71

## Solution description
There are two fields now in the phone number object now, i.e. country code (eg. 1, 64) and region code (eg. US, UK).

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
