### PR TITLE
Error on null region on validate method (iOS)

### DIFF
--- a/ios/Classes/SwiftPhoneNumberPlugin.swift
+++ b/ios/Classes/SwiftPhoneNumberPlugin.swift
@@ -26,15 +26,18 @@ public class SwiftPhoneNumberPlugin: NSObject, FlutterPlugin {
     private func validate(_ call: FlutterMethodCall, result: FlutterResult){
         guard
             let arguments = call.arguments as? [String : Any],
-            let number = arguments["string"] as? String,
-            let region = arguments["region"] as? String
+            let number = arguments["string"] as? String
+
             else {
                 result(FlutterError(code: "InvalidArgument",
                                     message: "The 'string' argument is missing.",
                                     details: nil))
                 return
         }
-        let isValid = kit.isValidPhoneNumber(number,withRegion: region);
+
+        let region = arguments["region"] as? String?
+
+        let isValid = region != nil ? kit.isValidPhoneNumber(number, withRegion: region!!) : kit.isValidPhoneNumber(number);
           let res:[String: Bool] = [
                     "isValid": isValid
                 ]


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #82 

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #73 

## Solution description
Validating number with no region code.

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
