### PR TITLE
regionCode is never mutated

### DIFF
--- a/ios/Classes/SwiftPhoneNumberPlugin.swift
+++ b/ios/Classes/SwiftPhoneNumberPlugin.swift
@@ -110,7 +110,7 @@ public class SwiftPhoneNumberPlugin: NSObject, FlutterPlugin {
             // - the number formatted as a national number and without the international prefix
             // - the number type (might not be 100% auccurate)
 
-            var regionCode = kit.getRegionCode(of: phoneNumber)
+            let regionCode = kit.getRegionCode(of: phoneNumber)
 
             return [
                 "type": phoneNumber.type.toString(),


### PR DESCRIPTION
Fix warning: Variable `regionCode` was never mutated; consider changing to 'let' constant

## Connection with issue(s)
N/A

## Solution description
Simple warning fix for constant variable

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
