### PR TITLE
Getting region code from number rather than country code

### DIFF
--- a/android/src/main/java/com/julienvignali/phone_number/PhoneNumberPlugin.java
+++ b/android/src/main/java/com/julienvignali/phone_number/PhoneNumberPlugin.java
@@ -171,7 +171,7 @@ public class PhoneNumberPlugin implements FlutterPlugin, MethodCallHandler {
                 util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.INTERNATIONAL));
         put("national", util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.NATIONAL));
         put("country_code", String.valueOf(countryCode));
-        put("region_code", String.valueOf(util.getRegionCodeForCountryCode(countryCode)));
+        put("region_code", String.valueOf(util.getRegionCodeForNumber(phoneNumber)));
         put("national_number", String.valueOf(phoneNumber.getNationalNumber()));
       }};
     } catch (NumberParseException e) {


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #107

## Solution description

This fix is only need for Android. For iOS it is working properly.

Previously Region Code was parsed using getRegionCodeForCountryCode() function but the country code for US and Canada is same '+1' so it always returned 'US'.  

In updated code it uses getRegionCodeForNumber() function that gives accurate Region code which considers whole phone number. So it returns right Region code.
